### PR TITLE
Updated glue jobs scripts to dynamically update glue table schema from json file

### DIFF
--- a/python scripts/accelerometer_trusted_zone.py
+++ b/python scripts/accelerometer_trusted_zone.py
@@ -34,6 +34,8 @@ DropFields_node1742775966451 = DropFields.apply(frame=CustomerPrivacyFilter_node
 
 # Script generated for node Amazon S3
 EvaluateDataQuality().process_rows(frame=DropFields_node1742775966451, ruleset=DEFAULT_DATA_QUALITY_RULESET, publishing_options={"dataQualityEvaluationContext": "EvaluateDataQuality_node1742774161136", "enableDataQualityResultsPublishing": True}, additional_options={"dataQualityResultsPublishing.strategy": "BEST_EFFORT", "observations.scope": "ALL"})
-AmazonS3_node1742775872050 = glueContext.write_dynamic_frame.from_options(frame=DropFields_node1742775966451, connection_type="s3", format="json", connection_options={"path": "s3://kgolovko-lake-house/accelerometer/trusted/", "partitionKeys": []}, transformation_ctx="AmazonS3_node1742775872050")
-
+AmazonS3_node1742775872050 = glueContext.getSink(path="s3://kgolovko-lake-house/accelerometer/trusted/", connection_type="s3", updateBehavior="UPDATE_IN_DATABASE", partitionKeys=[], enableUpdateCatalog=True, transformation_ctx="AmazonS3_node1742775872050")
+AmazonS3_node1742775872050.setCatalogInfo(catalogDatabase="kgolovko-db",catalogTableName="accelerometer_trusted")
+AmazonS3_node1742775872050.setFormat("json")
+AmazonS3_node1742775872050.writeFrame(DropFields_node1742775966451)
 job.commit()

--- a/python scripts/customer_curated_zone.py
+++ b/python scripts/customer_curated_zone.py
@@ -39,6 +39,8 @@ DropDuplicates_node1742791193398 =  DynamicFrame.fromDF(DropFields_node174278969
 
 # Script generated for node Customers curated
 EvaluateDataQuality().process_rows(frame=DropDuplicates_node1742791193398, ruleset=DEFAULT_DATA_QUALITY_RULESET, publishing_options={"dataQualityEvaluationContext": "EvaluateDataQuality_node1742776887734", "enableDataQualityResultsPublishing": True}, additional_options={"dataQualityResultsPublishing.strategy": "BEST_EFFORT", "observations.scope": "ALL"})
-Customerscurated_node1742789698636 = glueContext.write_dynamic_frame.from_options(frame=DropDuplicates_node1742791193398, connection_type="s3", format="json", connection_options={"path": "s3://kgolovko-lake-house/customer/curated/", "partitionKeys": []}, transformation_ctx="Customerscurated_node1742789698636")
-
+Customerscurated_node1742789698636 = glueContext.getSink(path="s3://kgolovko-lake-house/customer/curated/", connection_type="s3", updateBehavior="UPDATE_IN_DATABASE", partitionKeys=[], enableUpdateCatalog=True, transformation_ctx="Customerscurated_node1742789698636")
+Customerscurated_node1742789698636.setCatalogInfo(catalogDatabase="kgolovko-db",catalogTableName="customers_curated")
+Customerscurated_node1742789698636.setFormat("json")
+Customerscurated_node1742789698636.writeFrame(DropDuplicates_node1742791193398)
 job.commit()

--- a/python scripts/customer_trusted_zone.py
+++ b/python scripts/customer_trusted_zone.py
@@ -29,6 +29,8 @@ PrivacyFilter_node1742729757213 = Filter.apply(frame=AmazonS3_node1742697098644,
 
 # Script generated for node Trusted Customer Zone
 EvaluateDataQuality().process_rows(frame=PrivacyFilter_node1742729757213, ruleset=DEFAULT_DATA_QUALITY_RULESET, publishing_options={"dataQualityEvaluationContext": "EvaluateDataQuality_node1742696902238", "enableDataQualityResultsPublishing": True}, additional_options={"dataQualityResultsPublishing.strategy": "BEST_EFFORT", "observations.scope": "ALL"})
-TrustedCustomerZone_node1742697151222 = glueContext.write_dynamic_frame.from_options(frame=PrivacyFilter_node1742729757213, connection_type="s3", format="json", connection_options={"path": "s3://kgolovko-lake-house/customer/trusted/", "partitionKeys": []}, transformation_ctx="TrustedCustomerZone_node1742697151222")
-
+TrustedCustomerZone_node1742697151222 = glueContext.getSink(path="s3://kgolovko-lake-house/customer/trusted/", connection_type="s3", updateBehavior="UPDATE_IN_DATABASE", partitionKeys=[], enableUpdateCatalog=True, transformation_ctx="TrustedCustomerZone_node1742697151222")
+TrustedCustomerZone_node1742697151222.setCatalogInfo(catalogDatabase="kgolovko-db",catalogTableName="customer_trusted")
+TrustedCustomerZone_node1742697151222.setFormat("json")
+TrustedCustomerZone_node1742697151222.writeFrame(PrivacyFilter_node1742729757213)
 job.commit()

--- a/python scripts/machine_learning_curated_zone.py
+++ b/python scripts/machine_learning_curated_zone.py
@@ -37,6 +37,8 @@ Innerjoin_node1742855627373 = Join.apply(frame1=ChangeSchema_node1742861213267, 
 
 # Script generated for node Amazon S3
 EvaluateDataQuality().process_rows(frame=Innerjoin_node1742855627373, ruleset=DEFAULT_DATA_QUALITY_RULESET, publishing_options={"dataQualityEvaluationContext": "EvaluateDataQuality_node1742854347357", "enableDataQualityResultsPublishing": True}, additional_options={"dataQualityResultsPublishing.strategy": "BEST_EFFORT", "observations.scope": "ALL"})
-AmazonS3_node1742855738885 = glueContext.write_dynamic_frame.from_options(frame=Innerjoin_node1742855627373, connection_type="s3", format="json", connection_options={"path": "s3://kgolovko-lake-house/machine_learning/curated/", "partitionKeys": []}, transformation_ctx="AmazonS3_node1742855738885")
-
+AmazonS3_node1742855738885 = glueContext.getSink(path="s3://kgolovko-lake-house/machine_learning/curated/", connection_type="s3", updateBehavior="UPDATE_IN_DATABASE", partitionKeys=[], enableUpdateCatalog=True, transformation_ctx="AmazonS3_node1742855738885")
+AmazonS3_node1742855738885.setCatalogInfo(catalogDatabase="kgolovko-db",catalogTableName="machine_learning_curated")
+AmazonS3_node1742855738885.setFormat("json")
+AmazonS3_node1742855738885.writeFrame(Innerjoin_node1742855627373)
 job.commit()

--- a/python scripts/step_trainer_trusted_zone.py
+++ b/python scripts/step_trainer_trusted_zone.py
@@ -34,6 +34,8 @@ DropFields_node1742868027374 = DropFields.apply(frame=Innerjoin_node174285449921
 
 # Script generated for node Amazon S3
 EvaluateDataQuality().process_rows(frame=DropFields_node1742868027374, ruleset=DEFAULT_DATA_QUALITY_RULESET, publishing_options={"dataQualityEvaluationContext": "EvaluateDataQuality_node1742854347357", "enableDataQualityResultsPublishing": True}, additional_options={"dataQualityResultsPublishing.strategy": "BEST_EFFORT", "observations.scope": "ALL"})
-AmazonS3_node1742854997526 = glueContext.write_dynamic_frame.from_options(frame=DropFields_node1742868027374, connection_type="s3", format="json", connection_options={"path": "s3://kgolovko-lake-house/step_trainer/trusted/", "partitionKeys": []}, transformation_ctx="AmazonS3_node1742854997526")
-
+AmazonS3_node1742854997526 = glueContext.getSink(path="s3://kgolovko-lake-house/step_trainer/trusted/", connection_type="s3", updateBehavior="UPDATE_IN_DATABASE", partitionKeys=[], enableUpdateCatalog=True, transformation_ctx="AmazonS3_node1742854997526")
+AmazonS3_node1742854997526.setCatalogInfo(catalogDatabase="kgolovko-db",catalogTableName="step_trainer_trusted")
+AmazonS3_node1742854997526.setFormat("json")
+AmazonS3_node1742854997526.writeFrame(DropFields_node1742868027374)
 job.commit()


### PR DESCRIPTION
- enabled " set the Create a table in the Data Catalog and, on subsequent runs, update the schema and add new partitions" option in the target part of the visual etl
- regenerated the scripts